### PR TITLE
feat : add support for unary oparators

### DIFF
--- a/lexer/src/lexer.rs
+++ b/lexer/src/lexer.rs
@@ -1257,14 +1257,14 @@ mod lexer_tests {
     #[test]
     fn should_read_if_else_return_keywords() {
         let mut lx = Lexer::new(String::from(
-            "        
+            "
         if {
             return;
         }else{
             return;
-        }      
-        
-        
+        }
+
+
         ",
         ));
 
@@ -1610,7 +1610,7 @@ mod lexer_tests {
         let is_active @bool = true;
 
         let is_live @bool = false;
-        
+
         ",
         ));
         assert_eq!(
@@ -2009,10 +2009,10 @@ mod lexer_tests {
         let greeter @unit = fn(name @string) {
             print(\"Hi you\");
             let msg @string = format(\"Hi you #name\");
-        };  
+        };
 
         greeter();
-        
+
         ",
         ));
 
@@ -2166,11 +2166,11 @@ mod lexer_tests {
         let mut lx = Lexer::new(String::from(
             "
         @main fn(){
-            let x @int = 5;            
-            let name @string = \"Karis\";       
-            
-        }@end;           
-            
+            let x @int = 5;
+            let name @string = \"Karis\";
+
+        }@end;
+
         ",
         ));
 
@@ -2273,7 +2273,7 @@ mod lexer_tests {
     #[test]
     fn should_read_array1() {
         let mut lx = Lexer::new(String::from(
-            "     
+            "
         let numbers [ @int ];
         ",
         ));
@@ -2307,7 +2307,7 @@ mod lexer_tests {
     #[test]
     fn should_read_array2() {
         let mut lx = Lexer::new(String::from(
-            "     
+            "
         let numbers [ @int];
         ",
         ));
@@ -2330,7 +2330,7 @@ mod lexer_tests {
     #[test]
     fn should_read_array3() {
         let mut lx = Lexer::new(String::from(
-            "     
+            "
         let numbers [ @int ] = [ 1, 2, 3 ];
         ",
         ));
@@ -2408,7 +2408,7 @@ mod lexer_tests {
         let mut lx = Lexer::new(String::from(
             "
         let take_items [ @int ] = fn (items [ @int ]){
-            return items;  
+            return items;
         };
 
         ",
@@ -2504,6 +2504,133 @@ mod lexer_tests {
         assert_eq!(
             lx.read_tokens().unwrap().token_type,
             tokens::IdentifierKind::SEMICOLON
+        );
+    }
+
+    #[test]
+    fn should_try_to_read_golang_program() {
+        let mut lx = Lexer::new(String::from(
+            "
+            package main
+
+            import \"fmt\"
+
+            func main() {
+
+                if 7 % 2 == 0 {
+                    fmt.Println(\"7 is even\")
+                } else {
+                    fmt.Println(\"7 is odd\")
+                }
+
+                if 8 % 4 == 0 {
+                    fmt.Println(\"8 is divisible by 4\")
+                }
+
+                if num := 9; num < 0 {
+                    fmt.Println(num, \"is negative\")
+                } else if num < 10 {
+                    fmt.Println(num, \"has 1 digit\")
+                } else {
+                    fmt.Println(num, \"has multiple digits\")
+                }
+            }
+
+        ",
+        ));
+
+        assert_eq!(
+            lx.read_tokens().unwrap().token_type,
+            tokens::IdentifierKind::VARIABLE
+        );
+
+        assert!(lx.read_tokens().is_err());
+
+        assert_eq!(
+            lx.read_tokens().unwrap().token_type,
+            tokens::IdentifierKind::VARIABLE
+        );
+
+        assert_eq!(
+            lx.read_tokens().unwrap().token_type,
+            tokens::IdentifierKind::STRINGLITERAL
+        );
+
+        assert_eq!(
+            lx.read_tokens().unwrap().token_type,
+            tokens::IdentifierKind::VARIABLE
+        );
+
+        assert_eq!(
+            lx.read_tokens().unwrap().token_type,
+            tokens::IdentifierKind::CALLER
+        );
+
+        assert_eq!(
+            lx.read_tokens().unwrap().token_type,
+            tokens::IdentifierKind::LPAREN
+        );
+
+        assert_eq!(
+            lx.read_tokens().unwrap().token_type,
+            tokens::IdentifierKind::RPAREN
+        );
+
+        assert_eq!(
+            lx.read_tokens().unwrap().token_type,
+            tokens::IdentifierKind::LBRACE
+        );
+
+        assert_eq!(
+            lx.read_tokens().unwrap().token_type,
+            tokens::IdentifierKind::IF
+        );
+
+        assert_eq!(
+            lx.read_tokens().unwrap().token_type,
+            tokens::IdentifierKind::INTLITERAL
+        );
+
+        assert_eq!(
+            lx.read_tokens().unwrap().token_type,
+            tokens::IdentifierKind::MODULUS
+        );
+
+        assert_eq!(
+            lx.read_tokens().unwrap().token_type,
+            tokens::IdentifierKind::INTLITERAL
+        );
+
+        assert_eq!(
+            lx.read_tokens().unwrap().token_type,
+            tokens::IdentifierKind::EQ
+        );
+
+        assert_eq!(
+            lx.read_tokens().unwrap().token_type,
+            tokens::IdentifierKind::INTLITERAL
+        );
+
+        assert_eq!(
+            lx.read_tokens().unwrap().token_type,
+            tokens::IdentifierKind::LBRACE
+        );
+
+        assert!(lx.read_tokens().is_err(),);
+
+        assert_eq!(
+            lx.read_tokens().unwrap().token_type,
+            tokens::IdentifierKind::LPAREN
+        );
+
+        assert_eq!(
+            lx.read_tokens().unwrap().token_type,
+            tokens::IdentifierKind::STRINGLITERAL
+        );
+
+        assert_eq!(
+            lx.read_tokens().unwrap().token_type,
+            tokens::IdentifierKind::RPAREN
         );
     }
 }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -762,7 +762,7 @@ mod parser_tests {
             let greeter @unit = fn(name @string) {
                 print(\"Hi you\");
                 let msg @string = format(\"Hi you #name\");
-            }; 
+            };
 
 
         ",
@@ -780,7 +780,7 @@ mod parser_tests {
                 if x > y{
                     return x;
                 };
-            
+
                 return y;
             };
         ",
@@ -800,7 +800,7 @@ mod parser_tests {
                 }else x > y{
                     return x - y;
                 };
-            
+
                 return x * y;
             };
         ",
@@ -813,17 +813,17 @@ mod parser_tests {
     #[test]
     fn should_parse44() {
         let lx = Lexer::new(String::from(
-            " 
+            "
 
         let fibonacci @int = fn(n @int){
             if n == 0 {
                 return 0;
             };
-        
+
             if n == 1 || n == 2 {
                 return 1;
-            };           
-            
+            };
+
             return fibonacci(n - 1) + fibonacci(n - 2);
         };
 
@@ -837,17 +837,17 @@ mod parser_tests {
     #[test]
     fn should_parse45() {
         let lx = Lexer::new(String::from(
-            " 
+            "
 
         let fibonacci @int = fn(n @int){
             if n == 0 {
                 return 0;
             };
-        
+
             if n == 1 && n == 2 {
                 return 1;
             };
-        
+
             return fibonacci(n - 1) + fibonacci(n - 2);
         };
 
@@ -873,7 +873,7 @@ mod parser_tests {
             let result4 @string = echo(name);
             let result5 @int = echo(x,y);
             let result6 @int = add(x,y) + 5 / 10 * 9;
-            let result6 @int =  5 / 10 * 9 + add(x,y);  
+            let result6 @int =  5 / 10 * 9 + add(x,y);
             let result7 @int = factorial(5);
             let result8 @int = fibonacci(3);
 
@@ -883,8 +883,8 @@ mod parser_tests {
             print(result3);
             print(result4);
             print(result5);
-            print(result7);  
-            print(result8);            
+            print(result7);
+            print(result8);
         }@end;
         ",
         ));
@@ -905,5 +905,77 @@ mod parser_tests {
         let mut parser = Parser::new(lx);
         let _res = parser.parse(Some("should_parse47.json"))?;
         Ok(())
+    }
+
+    #[test]
+    fn should_parse48() {
+        let lx = Lexer::new(String::from("true && true;"));
+        let mut parser = Parser::new(lx);
+        let res = parser.parse(Some("should_parse48.json"));
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn should_parse49() {
+        let lx = Lexer::new(String::from("true && false;"));
+        let mut parser = Parser::new(lx);
+        let res = parser.parse(Some("should_parse49.json"));
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn should_parse50() {
+        let lx = Lexer::new(String::from("true & false;"));
+        let mut parser = Parser::new(lx);
+        let res = parser.parse(Some("should_parse50.json"));
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn should_parse51() {
+        let lx = Lexer::new(String::from("true || false;"));
+        let mut parser = Parser::new(lx);
+        let res = parser.parse(Some("should_parse51.json"));
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn should_parse52() {
+        let lx = Lexer::new(String::from("true | false;"));
+        let mut parser = Parser::new(lx);
+        let res = parser.parse(Some("should_parse52.json"));
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn should_parse53() {
+        let lx = Lexer::new(String::from("!true;"));
+        let mut parser = Parser::new(lx);
+        let res = parser.parse(Some("should_parse53.json"));
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn should_parse54() {
+        let lx = Lexer::new(String::from("!false"));
+        let mut parser = Parser::new(lx);
+        let res = parser.parse(Some("should_parse54.json"));
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn should_parse55() {
+        let lx = Lexer::new(String::from("!!false"));
+        let mut parser = Parser::new(lx);
+        let res = parser.parse(Some("should_parse55.json"));
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn should_parse56() {
+        let lx = Lexer::new(String::from("!!!!false"));
+        let mut parser = Parser::new(lx);
+        let res = parser.parse(Some("should_parse56.json"));
+        assert!(res.is_ok());
     }
 }

--- a/parser/src/registry.rs
+++ b/parser/src/registry.rs
@@ -42,6 +42,7 @@ impl TokenRegistry {
 
         self.add_minus_or_plus_as_prefix(IdentifierKind::MINUS);
         self.add_minus_or_plus_as_prefix(IdentifierKind::PLUS);
+        self.add_bang_as_prefix(IdentifierKind::BANG);
 
         self.add_assign();
 
@@ -61,6 +62,8 @@ impl TokenRegistry {
         self.add_infix(IdentifierKind::EQ, 60);
         self.add_infix(IdentifierKind::OR, 60);
         self.add_infix(IdentifierKind::AND, 60);
+        self.add_infix(IdentifierKind::LOR, 65);
+        self.add_infix(IdentifierKind::LAND, 65);
 
         self.add_call_declaration();
         self.add_function_declaration();
@@ -207,6 +210,15 @@ impl TokenRegistry {
     fn add_minus_or_plus_as_prefix(&mut self, symbol: IdentifierKind) {
         let obj = ParserType {
             nud_fn: Some(Self::parse_minus_or_plus_as_prefix),
+            led_fn: None,
+            binding_power: Some(10),
+        };
+        self.register(symbol, obj);
+    }
+
+    fn add_bang_as_prefix(&mut self, symbol: IdentifierKind) {
+        let obj = ParserType {
+            nud_fn: Some(Self::parse_bang_as_prefix),
             led_fn: None,
             binding_power: Some(10),
         };

--- a/parser/src/registry_led.rs
+++ b/parser/src/registry_led.rs
@@ -46,6 +46,22 @@ impl TokenRegistry {
 
         let next_token = next_token.unwrap();
 
+        if (current_token.token_type == IdentifierKind::AND
+            || current_token.token_type == IdentifierKind::LAND)
+            && (next_token.token_type == IdentifierKind::TRUE
+                || next_token.token_type == IdentifierKind::FALSE)
+        {
+            return Ok((current_token.clone(), next_token.clone()));
+        }
+
+        if (current_token.token_type == IdentifierKind::OR
+            || current_token.token_type == IdentifierKind::LOR)
+            && (next_token.token_type == IdentifierKind::TRUE
+                || next_token.token_type == IdentifierKind::FALSE)
+        {
+            return Ok((current_token.clone(), next_token.clone()));
+        }
+
         if identifiers.contains(&next_token.token_type) {
             return Err(errors::KarisError {
                 error_type: errors::KarisErrorType::InvalidSyntax,


### PR DESCRIPTION
- parse `!true` or `!!true` correctly
- parse infix `&&`, `&`, `||`,`|` to correctly anticipate right booleans

Signed-off-by: DavidDexter <dmwangi@kineticengines.co.ke>