### PR TITLE
feat : add support for unary oparators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,7 @@ Cargo.lock
 
 **/*.json
 
+dumps/
+
 
 # /home/daviddexter/kinetic-engines/kng-projects/karis-programming-language/testdata/test1.kr

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -5,9 +5,12 @@ edition = "2021"
 authors = ["Mwangi Kariuki <dmwangi@kineticengines.co.ke>"]
 repository = "https://github.com/daviddexter/karis-programming-language/console"
 
+[[bin]]
+name = "karis"
+path = "src/main.rs"
+
 
 [dependencies]
 clap = { version = "3.2.12", features = ["cargo"] }
 lexer = { path = "../lexer" }
 parser = { path = "../parser" }
-

--- a/console/Makefile
+++ b/console/Makefile
@@ -1,0 +1,2 @@
+install:
+	cargo install --path .

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -16,7 +16,7 @@ const KARIS_WELCOME_MESSAGE: &str = "
 ██░▄▀██░▀▀░█░▀▀▄██░▄█▄▄▀
 ██░██░█▄██▄█▄█▄▄█▄▄▄█▄▄▄
 ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-        
+
 ";
 
 const KARIS_INTERACTIVE_MESSAGE: &str = "
@@ -25,7 +25,7 @@ const KARIS_INTERACTIVE_MESSAGE: &str = "
 ██░▄▀██░▀▀░█░▀▀▄██░▄█▄▄▀
 ██░██░█▄██▄█▄█▄▄█▄▄▄█▄▄▄
 ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-        
+
 Welcome to Karis Lang (v0.1.0) Interactive Console";
 
 fn main() -> io::Result<()> {

--- a/parser/_x/_nodes_edges.py
+++ b/parser/_x/_nodes_edges.py
@@ -4,7 +4,7 @@ import graphviz
 
 def draw_node_and_edges(*args, **kwargs):
     """
-    dot.node('A', 'King Arthur')  
+    dot.node('A', 'King Arthur')
 
     dot.node('B', 'Sir Bedevere the Wise')
 
@@ -16,16 +16,14 @@ def draw_node_and_edges(*args, **kwargs):
     """
 
     nodes = args[0]
-    edges = args[1]   
+    edges = args[1]
 
-    graph = graphviz.Digraph('karis program', 
-    comment='Karis abstract syntax tree visualization', 
+    graph = graphviz.Digraph('karis program',
+    comment='Karis abstract syntax tree visualization',
     engine='sfdp', node_attr={'color': 'lightblue2', 'style': 'filled',
-    'shape': 'record', 'height': '.9','width': '.5'})    
+    'shape': 'record', 'height': '.9','width': '.5'})
 
     for node in nodes:
-        print(node[0] + ': ' + node[1])
-        
         if node[1] == "NODE(PROGRAM)":
             graph.node(node[0],node[1], style='filled', fillcolor='#36eee0', shape='circle')
         elif node[1] == "NODE(ASSIGN)":
@@ -49,6 +47,5 @@ def draw_node_and_edges(*args, **kwargs):
 
     g = graph.unflatten(stagger=1)
     g.format = 'png'
-    shutil.rmtree('render') 
+    shutil.rmtree('render')
     g.render(directory='render').replace('\\', '/')
-    

--- a/parser/src/objects.rs
+++ b/parser/src/objects.rs
@@ -117,12 +117,6 @@ impl Objects {
                 for object in body.iter() {
                     let (nodes, edges) = object.inspect();
 
-                    println!("{:?}\n", nodes);
-
-                    println!("{:?}\n", edges);
-
-                    //todo!("bug here: top-level LET vs function-level LET");
-
                     for node in nodes.iter() {
                         let kind = IdentifierKind::ASSIGN;
                         let assign_node_name = format!("NODE({kind:#?})");
@@ -151,22 +145,18 @@ impl Objects {
         use std::io::Write;
 
         let json = serde_json::to_string_pretty(self).unwrap();
-
         let file_name = json_name.unwrap_or("object.json");
-
         let mut curent_directory = std::env::current_dir()?;
 
-        if !std::fs::metadata(curent_directory.join("dumps"))?.is_dir() {
+        let exists = std::fs::metadata(curent_directory.join("dumps"));
+        if exists.is_err() {
             std::fs::create_dir(curent_directory.join("dumps"))?;
         }
 
         curent_directory.push("dumps/");
-
         let temp_file = curent_directory.join(file_name);
-
-        let mut file = std::fs::File::create(temp_file).unwrap();
-
-        file.write_all(json.as_bytes()).unwrap();
+        let mut file = std::fs::File::create(temp_file)?;
+        file.write_all(json.as_bytes())?;
 
         Ok(())
     }
@@ -394,6 +384,8 @@ impl Node {
                 | IdentifierKind::STRINGLITERAL => literals(self),
 
                 IdentifierKind::FUNCTION => function(self),
+
+                IdentifierKind::ARRAY => todo!("implement for array"),
 
                 _ => todo!("not implemented for {:?}", kind),
             }

--- a/testdata/00/test00.kr
+++ b/testdata/00/test00.kr
@@ -1,4 +1,4 @@
-let num @int = 1;        
+let num @int = 1;
 let active @bool = true;
 let subscribed @bool = false;
 let name @string = "Karis";


### PR DESCRIPTION
- parse `!true` or `!!true` correctly
- parse infix `&&`, `&`, `||`,`|` to correctly anticipate right booleans

Signed-off-by: DavidDexter <dmwangi@kineticengines.co.ke>